### PR TITLE
Implement AuthGuard example for AdonisJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# AdonisJS 6 Auth Guard Example
+
+This repository shows a minimal example of how a custom auth guard can support both **session** and **API consumer** flows using AdonisJS 6.
+
+## Features
+
+- `/auth/login` – Issues access and refresh tokens based on `grantType` (`session` or `api`).
+- `/auth/register` – Creates a new user and returns a session based token pair.
+- `/auth/refresh` – Exchanges a refresh token for a new access token.
+- Admin routes under `/api/clients` and `/auth/token/:id` to manage API clients and tokens.
+- `AuthGuard` class capable of authenticating via session cookies or bearer tokens with support for abilities stored on each token.
+
+The implementation uses in-memory stores for brevity, but can be wired to a database by replacing the storage layer.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "teste_lucas",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node src/server.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/src/auth/AuthGuard.ts
+++ b/src/auth/AuthGuard.ts
@@ -1,0 +1,80 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { randomUUID } from 'node:crypto'
+import { AuthToken, GrantType } from '../models/AuthToken'
+import { User } from '../models/User'
+
+// Simple in-memory stores for demonstration only
+const tokens: Record<string, AuthToken> = {}
+const users: Record<string, User> = {}
+
+export class AuthGuard {
+  constructor(private ctx: HttpContext) {}
+
+  /**
+   * Authenticate request using session or Bearer token.
+   * Provide expected grant types. When empty, accepts both.
+   */
+  public async authenticate(allow: GrantType[] = ['session', 'api']): Promise<User | null> {
+    const authorization = this.ctx.request.header('authorization')
+
+    if (authorization && authorization.startsWith('Bearer ')) {
+      const tokenId = authorization.replace('Bearer ', '')
+      const token = tokens[tokenId]
+      if (!token || token.revoked || token.expiresAt < new Date()) {
+        return null
+      }
+      if (!allow.includes(token.grantType)) {
+        return null
+      }
+      return users[token.userId] || null
+    }
+
+    // fallback to session
+    const sessionUserId = this.ctx.session.get('userId') as string | undefined
+    if (sessionUserId && allow.includes('session')) {
+      return users[sessionUserId] || null
+    }
+
+    return null
+  }
+
+  /**
+   * Generates a pair of access/refresh tokens for a user and grant type
+   */
+  public static issueTokens(user: User, grantType: GrantType, abilities: string[] = []): { accessToken: AuthToken; refreshToken: AuthToken } {
+    const now = new Date()
+    const accessToken: AuthToken = {
+      id: randomUUID(),
+      userId: user.id,
+      clientId: user.id,
+      grantType,
+      abilities,
+      revoked: false,
+      createdAt: now,
+      updatedAt: now,
+      expiresAt: new Date(now.getTime() + 1000 * 60 * 15), // 15min
+    }
+
+    const refreshToken: AuthToken = {
+      ...accessToken,
+      id: randomUUID(),
+      expiresAt: new Date(now.getTime() + 1000 * 60 * 60 * 24 * 30), // 30 days
+    }
+
+    tokens[accessToken.id] = accessToken
+    tokens[refreshToken.id] = refreshToken
+
+    return { accessToken, refreshToken }
+  }
+
+  public static revokeToken(id: string): void {
+    const token = tokens[id]
+    if (token) {
+      token.revoked = true
+    }
+  }
+
+  public static getToken(id: string): AuthToken | undefined {
+    return tokens[id]
+  }
+}

--- a/src/controllers/AdminController.ts
+++ b/src/controllers/AdminController.ts
@@ -1,0 +1,37 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { randomUUID } from 'node:crypto'
+import { AuthGuard } from '../auth/AuthGuard'
+import { AuthToken } from '../models/AuthToken'
+
+const apiClients: Record<string, { id: string; name: string; secret: string; active: boolean }> = {}
+
+export default class AdminController {
+  public async createClient({ request }: HttpContext) {
+    const name = request.input('name')
+    const client = { id: randomUUID(), name, secret: randomUUID(), active: true }
+    apiClients[client.id] = client
+    return client
+  }
+
+  public async listClients() {
+    return Object.values(apiClients)
+  }
+
+  public async updateClient({ params, request }: HttpContext) {
+    const client = apiClients[params.id]
+    if (!client) throw new Error('Not found')
+    Object.assign(client, request.only(['name', 'active']))
+    return client
+  }
+
+  public async getToken({ params }: HttpContext) {
+    const token = AuthGuard.getToken(params.id)
+    if (!token) throw new Error('Not found')
+    return token
+  }
+
+  public async revokeToken({ params }: HttpContext) {
+    AuthGuard.revokeToken(params.id)
+    return { success: true }
+  }
+}

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -1,0 +1,55 @@
+import { randomUUID } from 'node:crypto'
+import type { HttpContext } from '@adonisjs/core/http'
+import { AuthGuard } from '../auth/AuthGuard'
+import { User } from '../models/User'
+
+// In-memory store for demo
+const users: Record<string, User> = {}
+
+export default class AuthController {
+  public async register({ request }: HttpContext) {
+    const { email, password } = request.only(['email', 'password'])
+    const user: User = { id: randomUUID(), email, password, isActive: true }
+    users[user.id] = user
+    const tokens = AuthGuard.issueTokens(user, 'session')
+    return {
+      accessToken: tokens.accessToken.id,
+      refreshToken: tokens.refreshToken.id,
+      clientId: user.id,
+    }
+  }
+
+  public async login({ request, session }: HttpContext) {
+    const { identifier, secret, grantType } = request.only(['identifier', 'secret', 'grantType'])
+    const user = Object.values(users).find((u) => u.email === identifier)
+    if (!user || user.password !== secret) {
+      throw new Error('Invalid credentials')
+    }
+
+    if (grantType === 'session') {
+      session.put('userId', user.id)
+    }
+
+    const tokens = AuthGuard.issueTokens(user, grantType)
+    return {
+      accessToken: tokens.accessToken.id,
+      refreshToken: tokens.refreshToken.id,
+      clientId: user.id,
+    }
+  }
+
+  public async refresh({ request }: HttpContext) {
+    const { refreshToken } = request.only(['refreshToken'])
+    const token = AuthGuard.getToken(refreshToken)
+    if (!token || token.revoked || token.expiresAt < new Date()) {
+      throw new Error('Invalid token')
+    }
+    const user = users[token.userId]
+    const tokens = AuthGuard.issueTokens(user, token.grantType)
+    return {
+      accessToken: tokens.accessToken.id,
+      refreshToken: tokens.refreshToken.id,
+      clientId: user.id,
+    }
+  }
+}

--- a/src/models/AuthToken.ts
+++ b/src/models/AuthToken.ts
@@ -1,0 +1,13 @@
+export type GrantType = 'session' | 'api'
+
+export interface AuthToken {
+  id: string
+  userId: string
+  clientId: string
+  grantType: GrantType
+  abilities: string[]
+  revoked: boolean
+  createdAt: Date
+  updatedAt: Date
+  expiresAt: Date
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,0 +1,6 @@
+export interface User {
+  id: string
+  email: string
+  password: string
+  isActive: boolean
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,3 @@
+import { Ignitor } from '@adonisjs/core/build/standalone'
+
+new Ignitor(__dirname).httpServer().start()

--- a/src/start/routes.ts
+++ b/src/start/routes.ts
@@ -1,0 +1,28 @@
+import Route from '@adonisjs/core/services/router'
+import AuthController from '../controllers/AuthController'
+import AdminController from '../controllers/AdminController'
+import { AuthGuard } from '../auth/AuthGuard'
+
+const authController = new AuthController()
+const adminController = new AdminController()
+
+Route.post('/auth/login', (ctx) => authController.login(ctx))
+Route.post('/auth/register', (ctx) => authController.register(ctx))
+Route.post('/auth/refresh', (ctx) => authController.refresh(ctx))
+
+Route.group(() => {
+  Route.post('/api/clients', (ctx) => adminController.createClient(ctx))
+  Route.get('/api/clients', (ctx) => adminController.listClients())
+  Route.patch('/api/clients/:id', (ctx) => adminController.updateClient(ctx))
+  Route.get('/auth/token/:id', (ctx) => adminController.getToken(ctx))
+  Route.patch('/auth/token/:id', (ctx) => adminController.revokeToken(ctx))
+})
+  .middleware(async (ctx, next) => {
+    const guard = new AuthGuard(ctx)
+    const user = await guard.authenticate(['session', 'api'])
+    if (!user) {
+      ctx.response.status(401)
+      return
+    }
+    await next()
+  })


### PR DESCRIPTION
## Summary
- add package manifest and README for a minimal example project
- implement custom `AuthGuard` that authenticates via session or API tokens
- add example controllers for login, refresh, and admin operations
- wire routes and a lightweight server entrypoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684086a3af9c832fb90c8d8dd4e8d181