### PR TITLE
Implement password hashing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "teste_lucas",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "teste_lucas",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "bcryptjs": "^3.0.2"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "bcryptjs": "^3.0.2"
+  }
 }

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import type { HttpContext } from '@adonisjs/core/http'
 import { AuthGuard } from '../auth/AuthGuard'
 import { User } from '../models/User'
+import bcrypt from 'bcryptjs'
 
 // In-memory store for demo
 const users: Record<string, User> = {}
@@ -9,7 +10,8 @@ const users: Record<string, User> = {}
 export default class AuthController {
   public async register({ request }: HttpContext) {
     const { email, password } = request.only(['email', 'password'])
-    const user: User = { id: randomUUID(), email, password, isActive: true }
+    const hashedPassword = await bcrypt.hash(password, 10)
+    const user: User = { id: randomUUID(), email, password: hashedPassword, isActive: true }
     users[user.id] = user
     const tokens = AuthGuard.issueTokens(user, 'session')
     return {
@@ -22,7 +24,7 @@ export default class AuthController {
   public async login({ request, session }: HttpContext) {
     const { identifier, secret, grantType } = request.only(['identifier', 'secret', 'grantType'])
     const user = Object.values(users).find((u) => u.email === identifier)
-    if (!user || user.password !== secret) {
+    if (!user || !(await bcrypt.compare(secret, user.password))) {
       throw new Error('Invalid credentials')
     }
 


### PR DESCRIPTION
## Summary
- install `bcryptjs` for password hashing
- hash passwords on register
- verify hashed passwords on login

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849ec98e2bc832fa9b958d41bf0ced2